### PR TITLE
fix moving exec when bundling

### DIFF
--- a/cmd/goapp/mac.go
+++ b/cmd/goapp/mac.go
@@ -259,7 +259,7 @@ func createAppBundle(bundle driver.Bundle, root, appName string) error {
 	}
 
 	execName := filepath.Base(root)
-	if err := os.Rename(execName, filepath.Join(appName, "Contents", "MacOS", execName)); err != nil {
+	if err := os.Rename(execName, filepath.Join(appName, "Contents", "MacOS", bundle.AppName)); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## Summary
- fix the `goapp mac build -bundle` command when specifying a app name.

## Fixes
fix #175 