### PR TITLE
Added MFi Controller Support

### DIFF
--- a/app.go
+++ b/app.go
@@ -131,6 +131,14 @@ func NewContextMenu(c MenuConfig) Menu {
 	return driver.NewContextMenu(c)
 }
 
+// NewController creates the controller described by the given
+// configuration.
+//
+// It panics if called before Run.
+func NewController(c ControllerConfig) Controller {
+	return driver.NewController(c)
+}
+
 // NewFilePanel creates and displays the file panel described by the given
 // configuration.
 //

--- a/app_test.go
+++ b/app_test.go
@@ -43,6 +43,7 @@ func TestApp(t *testing.T) {
 		assert.NotNil(t, app.NewWindow(app.WindowConfig{}))
 		assert.NotNil(t, app.NewPage(app.PageConfig{}))
 		assert.NotNil(t, app.NewContextMenu(app.MenuConfig{}))
+		assert.NotNil(t, app.NewController(app.ControllerConfig{}))
 		assert.NotNil(t, app.NewFilePanel(app.FilePanelConfig{}))
 		assert.NotNil(t, app.NewSaveFilePanel(app.SaveFilePanelConfig{}))
 		assert.NotNil(t, app.NewShare("boo"))

--- a/controller.go
+++ b/controller.go
@@ -1,0 +1,49 @@
+package app
+
+// ControllerInput describes a controller input.
+type ControllerInput int
+
+// Constants that describe the controller inputs.
+const (
+	DirectionalPad ControllerInput = iota
+	LeftThumbstick
+	RightThumbstick
+	LeftThumbstickButton
+	RightThumbstickButton
+	A
+	B
+	X
+	Y
+	L1
+	L2
+	R1
+	R2
+	Pause
+)
+
+// ControllerConfig is a struct that describes a controller.
+type ControllerConfig struct {
+	// The function that is called when when the directional pad is pressed.
+	OnDpadChange func(in ControllerInput, x float64, y float64) `json:"-"`
+
+	// The function that is called when a button in pressed.
+	OnButtonChange func(in ControllerInput, value float64, pressed bool) `json:"-"`
+
+	// The function that is called when the controller is connected.
+	OnConnected func() `json:"-"`
+
+	// The function that is called when the controller is disconnected.
+	OnDisconnected func() `json:"-"`
+
+	// The function that is called when the pause button is pressed.
+	OnPause func() `json:"-"`
+
+	// The function that is called when the controller is closed.
+	OnClose func() `json:"-"`
+}
+
+// Controller is the interface that describes the controller.
+type Controller interface {
+	Elem
+	Closer
+}

--- a/driver.go
+++ b/driver.go
@@ -34,6 +34,9 @@ type Driver interface {
 	// given configuration.
 	NewContextMenu(MenuConfig) Menu
 
+	// NewController creates the controller described by the given configuration.
+	NewController(ControllerConfig) Controller
+
 	// NewFilePanel creates and displays the file panel described by the given
 	// configuration.
 	NewFilePanel(FilePanelConfig) Elem

--- a/drivers/mac/bridge.go
+++ b/drivers/mac/bridge.go
@@ -8,6 +8,7 @@ package mac
 #cgo LDFLAGS: -framework WebKit
 #cgo LDFLAGS: -framework CoreImage
 #cgo LDFLAGS: -framework Security
+#cgo LDFLAGS: -framework GameController
 #include "bridge.h"
 */
 import "C"

--- a/drivers/mac/controller.go
+++ b/drivers/mac/controller.go
@@ -1,0 +1,157 @@
+// +build darwin,amd64
+
+package mac
+
+import (
+	"github.com/google/uuid"
+	"github.com/murlokswarm/app"
+	"github.com/murlokswarm/app/internal/bridge"
+	"github.com/murlokswarm/app/internal/core"
+)
+
+// Controller implements the core.Elem struct
+type Controller struct {
+	core.Controller
+
+	id string
+
+	// Event handlers
+	onDpadChange   func(app.ControllerInput, float64, float64)
+	onButtonChange func(app.ControllerInput, float64, bool)
+	onConnected    func()
+	onDisconnected func()
+	onPause        func()
+	onClose        func()
+}
+
+func newController(c app.ControllerConfig) *Controller {
+	controller := &Controller{
+		id:             uuid.New().String(),
+		onDpadChange:   c.OnDpadChange,
+		onButtonChange: c.OnButtonChange,
+		onConnected:    c.OnConnected,
+		onDisconnected: c.OnDisconnected,
+		onPause:        c.OnPause,
+		onClose:        c.OnClose,
+	}
+
+	if err := driver.macRPC.Call("controller.New", nil, struct {
+		ID string
+	}{
+		ID: controller.id,
+	}); err != nil {
+		controller.SetErr(err)
+		return controller
+	}
+
+	driver.elems.Put(controller)
+	return controller
+}
+
+// ID satistfies the app.Elem interface.
+func (c *Controller) ID() string {
+	return c.id
+}
+
+// Close satisfies the app.Controller interface
+func (c *Controller) Close() {
+	err := driver.macRPC.Call("controller.Close", nil, struct {
+		ID string
+	}{
+		ID: c.id,
+	})
+
+	c.SetErr(err)
+	driver.elems.Delete(c)
+}
+
+// Called when either the directional pad or thumbsticks' values are changed (controller.onDpadChange)
+// Available values for `button`:
+//		dpad, leftThumbstick, rightThumbstick
+func onControllerDpadChange(c *Controller, in map[string]interface{}) interface{} {
+	if c.onDpadChange != nil {
+		c.onDpadChange(
+			app.ControllerInput(in["Input"].(float64)),
+			in["X"].(float64),
+			in["Y"].(float64),
+		)
+	}
+
+	return nil
+}
+
+// Called when one of the following buttons' values are changed (controller.onButtonChange)
+// Available values for `button`:
+//		buttonA, buttonB, buttonX, buttonY,
+//		leftShoulder, rightShoulder
+//		leftTrigger, rightTrigger
+func onControllerButtonChange(c *Controller, in map[string]interface{}) interface{} {
+	if c.onButtonChange != nil {
+		c.onButtonChange(
+			app.ControllerInput(in["Input"].(float64)),
+			in["Value"].(float64),
+			in["Pressed"].(bool),
+		)
+	}
+
+	return nil
+}
+
+// Called when the pause button is called.
+func onControllerPause(c *Controller, in map[string]interface{}) interface{} {
+	if c.onPause != nil {
+		c.onPause()
+	}
+
+	return nil
+}
+
+// Called when the controller is intentionally removed from the application
+func onControllerClose(c *Controller, in map[string]interface{}) interface{} {
+	if c.onClose != nil {
+		c.onClose()
+	}
+
+	return nil
+}
+
+// Called when a controller becomes connected.
+func onControllerConnected(c *Controller, in map[string]interface{}) interface{} {
+	if err := driver.macRPC.Call("controller.Listen", nil, struct {
+		ID string
+	}{
+		ID: c.id,
+	}); err != nil {
+		c.SetErr(err)
+		return c
+	}
+
+	if c.onConnected != nil {
+		c.onConnected()
+	}
+
+	return nil
+}
+
+// Called when a controller becomes disconnected.
+func onControllerDisconnected(c *Controller, in map[string]interface{}) interface{} {
+	if c.onDisconnected != nil {
+		c.onDisconnected()
+	}
+
+	return nil
+}
+
+func handleController(h func(c *Controller, in map[string]interface{}) interface{}) bridge.GoRPCHandler {
+	return func(in map[string]interface{}) interface{} {
+		id, _ := in["ID"].(string)
+		e := driver.elems.GetByID(id)
+
+		if e.Err() == app.ErrElemNotSet {
+			return nil
+		}
+
+		c := e.(*Controller)
+		return h(c, in)
+	}
+}

--- a/drivers/mac/controller.h
+++ b/drivers/mac/controller.h
@@ -1,0 +1,37 @@
+#ifndef controller_h
+#define controller_h
+
+#import <GameController/GCController.h>
+
+typedef enum ControllerInput : NSUInteger {
+	DirectionalPad,
+	LeftThumbstick,
+	RightThumbstick,
+	LeftThumbstickButton,
+	RightThumbstickButton,
+	A,
+	B,
+	X,
+	Y,
+	L1,
+	L2,
+	R1,
+	R2,
+	Pause
+} ControllerInput;
+
+@interface Controller : GCEventViewController
+@property NSString *ID;
+@property GCController *context;
+@property GCExtendedGamepad *profile;
++ (void) new:(NSDictionary *)in return:(NSString *)returnID;
++ (void) emitButton:(NSString *)ID Input:(int)input Value:(float)value Pressed:(BOOL)pressed;
++ (void) emitDpad:(NSString *)ID Input:(int)input X:(float)x Y:(float)y;
++ (void) close:(NSDictionary *)in return:(NSString *)returnID;
++ (void) listen:(NSDictionary *)in return:(NSString *)returnID;
+
+- (void) connected;
+- (void) disconnected;
+@end
+
+#endif /* controller_h */

--- a/drivers/mac/controller.m
+++ b/drivers/mac/controller.m
@@ -1,0 +1,156 @@
+#include "driver.h"
+#include "controller.h"
+
+@implementation Controller
+
+// Create a new Controller that will listen for and
+// dispatch MFi controller events.
++ (void) new:(NSDictionary *)in return:(NSString *)returnID {
+  defer(returnID, ^{
+    Driver *driver = [Driver current];
+    NSString *ID = in[@"ID"];
+
+    // Create blank controller, track it for future connection
+    Controller *controller = [[Controller alloc] init];
+    controller.ID = ID;
+    driver.elements[ID] = controller;
+
+    // Register for controller connection notifications
+    [[NSNotificationCenter defaultCenter] addObserver:controller selector:@selector(connected) name:GCControllerDidConnectNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:controller selector:@selector(disconnected) name:GCControllerDidDisconnectNotification object:nil];
+
+    // Check if controller was connected before application started
+    if ([[GCController controllers] count] > 0) {
+        [controller connected];
+    }
+
+    [driver.macRPC return:returnID withOutput:nil andError:nil];
+  });
+}
+
+// Called when a controller becomes connected
+- (void) connected {
+    Driver *driver = [Driver current];
+    self.context = [GCController controllers][0];
+    self.profile = self.context.extendedGamepad;
+    NSDictionary *in = @{
+        @"ID": self.ID,
+    };
+
+    [driver.goRPC call:@"controller.OnConnected" withInput:in onUI:YES];
+}
+
+// Called when a controller becomes disconnected
+- (void) disconnected {
+    Driver *driver = [Driver current];
+    NSDictionary *in = @{
+        @"ID": self.ID,
+    };
+
+    [driver.goRPC call:@"controller.OnDisconnected" withInput:in onUI:YES];
+}
+
+// Close removes the controller from the elements
++ (void) close:(NSDictionary *)in return:(NSString *)returnID {
+    Driver *driver = [Driver current];
+    NSString *ID = in[@"ID"];
+    Controller *controller = driver.elements[ID];
+
+    if (controller == nil) {
+      [NSException raise:@"ErrNoController" format:@"no controller with id %@", ID];
+    }
+    
+    [driver.goRPC call:@"controller.OnClose" withInput:in onUI:NO];
+
+    controller.context = nil;
+    controller.profile = nil;
+    [driver.elements removeObjectForKey:ID];
+
+    [driver.macRPC return:returnID withOutput:nil andError:nil];
+}
+
+// General, shorthand function for emitting controller.onButtonChange
++ (void) emitButton:(NSString *)ID Input:(int)input Value:(float)value Pressed:(BOOL)pressed {
+    Driver *driver = [Driver current];
+    NSDictionary *in = @{
+        @"ID": ID,
+        @"Input": @(input),
+        @"Value": @(value),
+        @"Pressed": @(pressed),
+    };
+
+    [driver.goRPC call:@"controller.OnButtonChange" withInput:in onUI:YES];
+}
+
+// General, shorthand function for emitting controller.onDpadChange
++ (void) emitDpad:(NSString *)ID Input:(int)input X:(float)x Y:(float)y {
+    Driver *driver = [Driver current];
+    NSDictionary *in = @{
+        @"ID": ID,
+        @"Input": @(input),
+        @"X": @(x),
+        @"Y": @(y),
+    };
+
+    [driver.goRPC call:@"controller.OnDpadChange" withInput:in onUI:YES];
+}
+
+// Sets up handler functions for the controller object
++ (void) listen:(NSDictionary *)in return:(NSString *)returnID {
+  defer(returnID, ^{
+    Driver *driver = [Driver current];
+    NSString *ID = in[@"ID"];
+
+    Controller *controller = driver.elements[ID];
+
+    controller.context.controllerPausedHandler = ^(GCController *controller)
+    {
+        [driver.goRPC call:@"controller.OnPause" withInput:in onUI:YES];
+    };
+
+    controller.profile.dpad.valueChangedHandler = ^(GCControllerDirectionPad *dpad, float x, float y) {
+        [Controller emitDpad:ID Input:DirectionalPad X:x Y:y];
+    };
+    controller.profile.leftThumbstick.valueChangedHandler = ^(GCControllerDirectionPad *dpad, float x, float y) {
+        [Controller emitDpad:ID Input:LeftThumbstick X:x Y:y];
+    };
+    controller.profile.rightThumbstick.valueChangedHandler = ^(GCControllerDirectionPad *dpad, float x, float y) {
+        [Controller emitDpad:ID Input:RightThumbstick X:x Y:y];
+    };
+    if (@available(macOS 10.14.1, *)) {
+        controller.profile.leftThumbstickButton.pressedChangedHandler = ^(GCControllerButtonInput *button, float value, BOOL pressed) {
+            [Controller emitButton:ID Input:LeftThumbstickButton Value:value Pressed:pressed];
+        };
+        controller.profile.rightThumbstickButton.pressedChangedHandler = ^(GCControllerButtonInput *button, float value, BOOL pressed) {
+            [Controller emitButton:ID Input:RightThumbstickButton Value:value Pressed:pressed];
+        };
+    }
+    controller.profile.buttonA.pressedChangedHandler = ^(GCControllerButtonInput *button, float value, BOOL pressed) {
+        [Controller emitButton:ID Input:A Value:value Pressed:pressed];
+    };
+    controller.profile.buttonB.pressedChangedHandler = ^(GCControllerButtonInput *button, float value, BOOL pressed) {
+        [Controller emitButton:ID Input:B Value:value Pressed:pressed];
+    };
+    controller.profile.buttonX.pressedChangedHandler = ^(GCControllerButtonInput *button, float value, BOOL pressed) {
+        [Controller emitButton:ID Input:X Value:value Pressed:pressed];
+    };
+    controller.profile.buttonY.pressedChangedHandler = ^(GCControllerButtonInput *button, float value, BOOL pressed) {
+        [Controller emitButton:ID Input:Y Value:value Pressed:pressed];
+    };
+    controller.profile.leftShoulder.pressedChangedHandler = ^(GCControllerButtonInput *button, float value, BOOL pressed) {
+        [Controller emitButton:ID Input:L1 Value:value Pressed:pressed];
+    };
+    controller.profile.leftTrigger.pressedChangedHandler = ^(GCControllerButtonInput *button, float value, BOOL pressed) {
+        [Controller emitButton:ID Input:L2 Value:value Pressed:pressed];
+    };
+    controller.profile.rightShoulder.pressedChangedHandler = ^(GCControllerButtonInput *button, float value, BOOL pressed) {
+        [Controller emitButton:ID Input:R1 Value:value Pressed:pressed];
+    };
+    controller.profile.rightTrigger.pressedChangedHandler = ^(GCControllerButtonInput *button, float value, BOOL pressed) {
+        [Controller emitButton:ID Input:R2 Value:value Pressed:pressed];
+    };
+
+    [driver.macRPC return:returnID withOutput:nil andError:nil];
+  });
+}
+@end

--- a/drivers/mac/driver.go
+++ b/drivers/mac/driver.go
@@ -148,6 +148,13 @@ func (d *Driver) Run(f *app.Factory) error {
 	d.goRPC.Handle("menus.OnClose", handleMenu(onMenuClose))
 	d.goRPC.Handle("menus.OnCallback", handleMenu(onMenuCallback))
 
+	d.goRPC.Handle("controller.OnButtonChange", handleController(onControllerButtonChange))
+	d.goRPC.Handle("controller.OnDpadChange", handleController(onControllerDpadChange))
+	d.goRPC.Handle("controller.OnConnected", handleController(onControllerConnected))
+	d.goRPC.Handle("controller.OnDisconnected", handleController(onControllerDisconnected))
+	d.goRPC.Handle("controller.OnPause", handleController(onControllerPause))
+	d.goRPC.Handle("controller.OnClose", handleController(onControllerClose))
+
 	d.goRPC.Handle("filePanels.OnSelect", handleFilePanel(onFilePanelSelect))
 	d.goRPC.Handle("saveFilePanels.OnSelect", handleSaveFilePanel(onSaveFilePanelSelect))
 
@@ -259,6 +266,11 @@ func (d *Driver) NewContextMenu(c app.MenuConfig) app.Menu {
 	err := d.macRPC.Call("driver.SetContextMenu", nil, m.ID())
 	m.SetErr(err)
 	return m
+}
+
+// NewController statisfies the app.Driver interface.
+func (d *Driver) NewController(c app.ControllerConfig) app.Controller {
+	return newController(c)
 }
 
 // NewFilePanel satisfies the app.Driver interface.

--- a/drivers/mac/driver.m
+++ b/drivers/mac/driver.m
@@ -1,3 +1,4 @@
+#include "controller.h"
 #include "driver.h"
 #include "dock.h"
 #include "json.h"
@@ -158,6 +159,20 @@
   [self.macRPC handle:@"docks.SetIcon"
           withHandler:^(id in, NSString *returnID) {
             return [Dock setIcon:in return:returnID];
+          }];
+
+  // Controller handlers.
+  [self.macRPC handle:@"controller.New"
+          withHandler:^(id in, NSString *returnID) {
+            return [Controller new:in return:returnID];
+          }];
+  [self.macRPC handle:@"controller.Listen"
+          withHandler:^(id in, NSString *returnID) {
+            return [Controller listen:in return:returnID];
+          }];
+  [self.macRPC handle:@"controller.Close"
+          withHandler:^(id in, NSString *returnID) {
+            return [Controller close:in return:returnID];
           }];
 
   // File panel handlers.

--- a/drivers/test/controller.go
+++ b/drivers/test/controller.go
@@ -1,0 +1,98 @@
+package test
+
+import (
+	"github.com/google/uuid"
+	"github.com/murlokswarm/app"
+	"github.com/murlokswarm/app/internal/core"
+)
+
+// Controller implements the core.Elem struct
+type Controller struct {
+	core.Controller
+
+	id     string
+	driver *Driver
+
+	// event handlers
+	onDpadChange   func(app.ControllerInput, float64, float64)
+	onButtonChange func(app.ControllerInput, float64, bool)
+	onConnected    func()
+	onDisconnected func()
+	onPause        func()
+	onClose        func()
+}
+
+func newController(d *Driver, c app.ControllerConfig) *Controller {
+	controller := &Controller{
+		id:             uuid.New().String(),
+		driver:         d,
+		onDpadChange:   c.OnDpadChange,
+		onButtonChange: c.OnButtonChange,
+		onConnected:    c.OnConnected,
+		onDisconnected: c.OnDisconnected,
+		onPause:        c.OnPause,
+		onClose:        c.OnClose,
+	}
+
+	d.elems.Put(controller)
+	return controller
+}
+
+// ID satistfies the app.Elem interface.
+func (c *Controller) ID() string {
+	return c.id
+}
+
+func onControllerDpadChange(c *Controller, in map[string]interface{}) interface{} {
+	if c.onDpadChange != nil {
+		input := app.ControllerInput(in["Input"].(float64))
+		x := in["X"].(float64)
+		y := in["Y"].(float64)
+		c.onDpadChange(input, x, y)
+	}
+
+	return nil
+}
+
+func onControllerButtonChange(c *Controller, in map[string]interface{}) interface{} {
+	if c.onButtonChange != nil {
+		input := app.ControllerInput(in["Input"].(float64))
+		value := in["Value"].(float64)
+		pressed := in["Pressed"].(bool)
+		c.onButtonChange(input, value, pressed)
+	}
+
+	return nil
+}
+
+func onControllerConnected(c *Controller, in map[string]interface{}) interface{} {
+	if c.onConnected != nil {
+		c.onConnected()
+	}
+
+	return nil
+}
+
+func onControllerDisconnected(c *Controller, in map[string]interface{}) interface{} {
+	if c.onDisconnected != nil {
+		c.onDisconnected()
+	}
+
+	return nil
+}
+
+func onControllerPause(c *Controller, in map[string]interface{}) interface{} {
+	if c.onPause != nil {
+		c.onPause()
+	}
+
+	return nil
+}
+
+func onControllerClose(c *Controller, in map[string]interface{}) interface{} {
+	if c.onClose != nil {
+		c.onClose()
+	}
+
+	return nil
+}

--- a/drivers/test/driver.go
+++ b/drivers/test/driver.go
@@ -86,6 +86,13 @@ func (d *Driver) NewContextMenu(c app.MenuConfig) app.Menu {
 	return m
 }
 
+// NewController satisfies the app.Driver interface.
+func (d *Driver) NewController(c app.ControllerConfig) app.Controller {
+	m := newController(d, c)
+	d.setElemErr(m)
+	return m
+}
+
 // MenuBar satisfies the app.Driver interface.
 func (d *Driver) MenuBar() app.Menu {
 	d.setElemErr(d.menubar)

--- a/internal/core/controller.go
+++ b/internal/core/controller.go
@@ -1,0 +1,13 @@
+package core
+
+import "github.com/murlokswarm/app"
+
+// Controller is a base struct to embed in app.Controller implementations.
+type Controller struct {
+	Elem
+}
+
+// Close satisfies the app.Controller interface.
+func (c *Controller) Close() {
+	c.SetErr(app.ErrNotSupported)
+}

--- a/internal/core/controller_test.go
+++ b/internal/core/controller_test.go
@@ -1,0 +1,13 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestController(t *testing.T) {
+	c := &Controller{}
+	c.Close()
+	assert.Error(t, c.Err())
+}

--- a/internal/core/driver.go
+++ b/internal/core/driver.go
@@ -93,6 +93,13 @@ func (d *Driver) MenuBar() app.Menu {
 	return m
 }
 
+// NewController satisfies the app.Driver interface.
+func (d *Driver) NewController(c app.ControllerConfig) app.Controller {
+	controller := &Controller{}
+	controller.SetErr(app.ErrNotSupported)
+	return controller
+}
+
 // NewStatusMenu satisfies the app.Driver interface.
 func (d *Driver) NewStatusMenu(c app.StatusMenuConfig) app.StatusMenu {
 	s := &StatusMenu{}

--- a/internal/core/driver_test.go
+++ b/internal/core/driver_test.go
@@ -43,6 +43,9 @@ func TestDriver(t *testing.T) {
 	mb := d.MenuBar()
 	assert.Error(t, mb.Err())
 
+	c := d.NewController(app.ControllerConfig{})
+	assert.Error(t, c.Err())
+
 	sm := d.NewStatusMenu(app.StatusMenuConfig{})
 	assert.Error(t, sm.Err())
 

--- a/internal/tests/controller.go
+++ b/internal/tests/controller.go
@@ -1,0 +1,13 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/murlokswarm/app"
+	"github.com/stretchr/testify/assert"
+)
+
+func testController(t *testing.T, c app.Controller) {
+	c.Close()
+	assert.Error(t, c.Err())
+}

--- a/internal/tests/driver.go
+++ b/internal/tests/driver.go
@@ -36,6 +36,10 @@ func TestDriver(t *testing.T, setup DriverSetup) {
 		assertElem(t, w)
 		t.Run("window", func(t *testing.T) { testWindow(t, w) })
 
+		c := d.NewController(app.ControllerConfig{})
+		assertElem(t, c)
+		t.Run("controller", func(t *testing.T) { testController(t, c) })
+
 		p := d.NewPage(app.PageConfig{})
 		assertElem(t, p)
 		t.Run("page", func(t *testing.T) { testPage(t, p) })

--- a/logs.go
+++ b/logs.go
@@ -101,6 +101,20 @@ func (d *driverWithLogs) NewContextMenu(c MenuConfig) Menu {
 	return &menuWithLogs{Menu: m}
 }
 
+func (d *driverWithLogs) NewController(c ControllerConfig) Controller {
+	WhenDebug(func() {
+		config, _ := json.MarshalIndent(c, "", "  ")
+		Logf("creating controller: %s", config)
+	})
+
+	controller := d.Driver.NewController(c)
+	if controller.Err() != nil {
+		Logf("creating controller failed: %s", controller.Err())
+	}
+
+	return &controllerWithLogs{Controller: controller}
+}
+
 func (d *driverWithLogs) NewFilePanel(c FilePanelConfig) Elem {
 	WhenDebug(func() {
 		config, _ := json.MarshalIndent(c, "", "  ")
@@ -379,6 +393,25 @@ func (w *windowWithLogs) Close() {
 		Logf("window %s failed to close: %s",
 			w.ID(),
 			w.Err(),
+		)
+	}
+}
+
+// Controller logs.
+type controllerWithLogs struct {
+	Controller
+}
+
+func (c *controllerWithLogs) Close() {
+	WhenDebug(func() {
+		Logf("controller %s is closing", c.ID())
+	})
+
+	c.Controller.Close()
+	if c.Err() != nil {
+		Logf("controller %s failed to close: %s",
+			c.ID(),
+			c.Err(),
 		)
 	}
 }


### PR DESCRIPTION
## Summary

I've written out a basic implementation for handling MFi controller events and providing Go callbacks that can be used to interact with the application. 

As per `CONTRIBUTING.md`:

- use gofmt ✅ 
- use govet ✅ 
- use golint ✅ 
- test coverage for . stay at 100% ✅ 
- test coverage for ./internal/appjs stays at 100% ✅ 
- test coverage for ./internal/bridge stays at 100% ✅ 
- test coverage for ./internal/html stays at 100% ✅ 
- test coverage for ./internal/core stays at 100% ✅ 
- try to keep consistent coding style ✅ 
- avoid naked returns (if you deal with a part of the code that have some, please refactor). ✅ (I tried my best at least 😄)
- run goreportcard with your branch, everything that is not gocyclo must be 100%. ✅ 

## Fixes

Using `GameController/GCController.h`, I setup handlers for the various buttons and dpads that comply with MFi. I've tested this with the Steelseries Nimbus and all keys register with their respective button.

I wanted to add DOM events, but the contributing doc said not to get too crazy. Happy to add if this is good.

## Example

This is how I've sandboxed the following changes:

```
package main

import (
	"github.com/murlokswarm/app"
	"github.com/murlokswarm/app/drivers/mac"
)

type MainWindow struct {
	Controller app.Controller
}

func (mw *MainWindow) Config() app.HTMLConfig {

	mw.Controller = app.NewController(app.ControllerConfig{
		OnConnected: func() {
			app.Log("OnConnected")
		},
		OnDisconnected: func() {
			app.Log("OnDisconnected")
		},
		OnPause: func() {
			app.Log("OnPause")
		},
		OnDpadChange: func(input app.ControllerInput, x float64, y float64) {
			switch input {
			case app.DirectionalPad:
				app.Logf("OnDpad -- directional pad, x: %f, y: %f", x, y)
			case app.LeftThumbstick:
				app.Logf("OnDpad -- left thumbstick, x: %f, y: %f", x, y)
			case app.RightThumbstick:
				app.Logf("OnDpad -- right thumbstick, x: %f, y: %f", x, y)
			}
		},
		OnButtonChange: func(input app.ControllerInput, value float64, pressed bool) {
			switch input {
			case app.A:
				app.Logf("OnButtonChange -- a button, value: %f, pressed: %t", value, pressed)
			case app.B:
				app.Logf("OnButtonChange -- b button, value: %f, pressed: %t", value, pressed)
			case app.X:
				app.Logf("OnButtonChange -- x button, value: %f, pressed: %t", value, pressed)
			case app.Y:
				app.Logf("OnButtonChange -- y button, value: %f, pressed: %t", value, pressed)
			case app.L1:
				app.Logf("OnButtonChange -- l1 button, value: %f, pressed: %t", value, pressed)
			case app.L2:
				app.Logf("OnButtonChange -- l2 button, value: %f, pressed: %t", value, pressed)
			case app.R1:
				app.Logf("OnButtonChange -- r1 button, value: %f, pressed: %t", value, pressed)
			case app.R2:
				app.Logf("OnButtonChange -- r2 button, value: %f, pressed: %t", value, pressed)
			}
		},
		OnClose: func() {
			app.Log("OnClose")
		},
	})
	// mw.Controller.Close()
	return app.HTMLConfig{}
}

func (mw *MainWindow) Render() string {
	return `
	<div class="MainWindow">Example</div>
	`
}

func init() {
	mw := &MainWindow{}
	app.Import(mw)
}

func main() {
	app.Run(&mac.Driver{
		URL: "/mainwindow",
	})
}
```

edit: updated sandbox example